### PR TITLE
RSV: neue DarlehensBetragsVorgabe RestVomFinanzierungsBedarfVorgabeMitRatenschutzAufschlag

### DIFF
--- a/api.json
+++ b/api.json
@@ -3049,6 +3049,7 @@
             "FESTER_BETRAG",
             "FESTER_BETRAG_MIT_AUFSCHLAG",
             "REST_VOM_FINANZIERUNGS_BEDARF",
+            "REST_VOM_FINANZIERUNGS_BEDARF_MIT_AUFSCHLAG",
             "ZIEL_BELEIHUNGS_AUSLAUF",
             "ZIEL_BELEIHUNGS_AUSLAUF_VOM_KREDITENTSCHEIDER",
             "PROZENTUALER_ANTEIL_FINANZIERUNGS_BEDARF",
@@ -3129,6 +3130,23 @@
           "properties": {
             "minimumRestVomFinanzierungsBedarf": {
               "$ref": "#/definitions/Money"
+            }
+          }
+        }
+      ]
+    },
+    "RestVomFinanzierungsBedarfVorgabeMitRatenschutzAufschlag": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/RestVomFinanzierungsBedarfVorgabe"
+        },
+        {
+          "properties": {
+            "aufschlagsVorgaben": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/RatenschutzAufschlagsVorgabe"
+              }
             }
           }
         }


### PR DESCRIPTION
... und neuer darlehensBetragsVorgabeTyp REST_VOM_FINANZIERUNGS_BEDARF_MIT_AUFSCHLAG, um auch Optionen mit RestVomFinanzierungsBdarf und RSV-Aufschlag verarbeiten zu können (z.B. Annu mit Kfw)

https://trello.com/c/qx1CUzLk