### PR TITLE
Auräumen nach OMC raus aus PEP

### DIFF
--- a/api.json
+++ b/api.json
@@ -2322,9 +2322,6 @@
         "kreditRaten": {
           "$ref": "#/definitions/Money"
         },
-        "kreditratenBestandsobjekte": {
-          "$ref": "#/definitions/Money"
-        },
         "lebensVersicherungsBeitraege": {
           "$ref": "#/definitions/Money"
         },


### PR DESCRIPTION
kreditratenBestandsobjekte wird nicht mehr im Code gesetzt (obsolet) und kann ausgebaut werden

https://trello.com/c/IetfpwF0