### PR TITLE
Ungenutztes Feld 'beleihungswertschaetzungDesVertriebes' entfernt.

### DIFF
--- a/api.json
+++ b/api.json
@@ -379,9 +379,6 @@
             "$ref": "#/definitions/BausparOption"
           }
         },
-        "beleihungsWertSchaetzungDesVertriebes": {
-          "$ref": "#/definitions/Money"
-        },
         "beratungsHonorar": {
           "$ref": "#/definitions/Money"
         },
@@ -2784,9 +2781,6 @@
     "FinanzierungsSpezifikation": {
       "type": "object",
       "properties": {
-        "beleihungswertschaetzungDesVertriebes": {
-          "$ref": "#/definitions/Money"
-        },
         "darlehen": {
           "type": "array",
           "items": {


### PR DESCRIPTION
Wurde in der FinanzierungsOption und -Spezifikation entfernt.

https://trello.com/c/52Rlpbfv