### PR TITLE
BEV: neue Liste von Ids ergänzt (annuitaetenDarlehenWuenscheOhneAuszahlungsDatum)

### DIFF
--- a/api.json
+++ b/api.json
@@ -1629,6 +1629,12 @@
             "$ref": "#/definitions/DarlehenEinerImmobilie"
           }
         },
+        "annuitaetenDarlehenWuenscheOhneAuszahlungsDatum": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Identifier"
+          }
+        },
         "objekte": {
           "type": "array",
           "items": {

--- a/api.json
+++ b/api.json
@@ -3037,6 +3037,12 @@
             "type": "string"
           }
         },
+        "meldungsCodes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "istEigenvertrieb": {
           "type": "boolean"
         }

--- a/beispiele/anfrage.json
+++ b/beispiele/anfrage.json
@@ -196,6 +196,7 @@
         }
       ],
       "nichtAbzuloesendeDarlehen": [],
+      "annuitaetenDarlehenWuenscheOhneAuszahlungsDatum": [],
       "objekte": [
         {
           "adresse": {

--- a/beispiele/antwort.json
+++ b/beispiele/antwort.json
@@ -883,7 +883,12 @@
           "optionaleSondertilgung": "5",
           "volltilgung": false,
           "zinsbindungInMonaten": 240,
-          "aktionsLabels": [ "Sonderaktion" ]
+          "aktionsLabels": [
+            "Sonderaktion"
+          ],
+          "meldungsCodes": [
+            "meldung.code"
+          ]
         },
         "tilgungsPlan": {
           "abschlussKosten": "0,00",


### PR DESCRIPTION
**Motivation**
--
In der PEP-ME wird es zukünftig eine Vorbehaltsmeldung geben, die darauf prüft, ob zu allen Annuitätendarlehenswünschen ein Auszahlungsdatum angegeben wurde. Diese Vorbehaltsmeldung soll perspektivisch auch bei FINMAS und GENOPACE genutzt werden.

https://europace.atlassian.net/browse/BEV-56
https://github.com/hypoport/pep-market-engine/pull/503

**Technische Anpassungen**
--
Ich habe die api.json erweitert um eine Liste von Ids. Diese Ids entsprechen den Ids, die von BaufiSmart über den BaufiSmartAnnuitaetenDarlehensWunsch mitgegeben werden. 

Weiterhin habe ich die api.json erweitert um eine Liste von Meldungscodes. Diese werden in der Spezifikation abgelegt um diese dann bei der Aktualisierung und Prüfung auswerten zu können.

**Hintergrundinformationen zu den verwendeten Ids**
--
Da diese Ids über den AnnuitaetenDarlehenWunsch, die AnnuitaetOption und letztlich die SpeedAnnuitaetenDarlehenSpezifikation weitergereicht werden, kann es in der Vorbehaltsmeldung einen Abgleich zwischen der Liste der Ids und der aktuellen SpeedAnnuitaetenDarlehenSpezifikation-Id geben. In der Vorbehaltsmeldung werden dann die Angaben aus der Spezifikation (Darlehenstyp, Darlehensbetrag) verwendet.

Für die Aktualisierung und Prüfung wird der Meldungscode der Vorbehaltsmeldung in der SpeedEigenDarlehenSpezifikation abgelegt und bei der Vorbehaltsprüfung ausgewertet (siehe dazu: https://github.com/hypoport/pep-market-engine/pull/503).




