### PR TITLE
BEV: SpeedAnnuitaetenDarlehenSpezifikationDto erweitert um "auszahlungsDatumArt"

### DIFF
--- a/api.json
+++ b/api.json
@@ -2901,6 +2901,9 @@
             "zinsbindungInMonaten": {
               "type": "integer",
               "format": "int32"
+            },
+            "auszahlungsDatumArt": {
+              "$ref": "#/definitions/AuszahlungsDatumArt"
             }
           }
         }
@@ -3234,6 +3237,14 @@
         "WUNSCH",
         "DEFAULT",
         "ANGEPASST"
+      ]
+    },
+    "AuszahlungsDatumArt": {
+      "type": "string",
+      "enum": [
+        "IM_WUNSCH_ANGEGEBEN",
+        "DEFAULT",
+        "KEINE_ANGABE"
       ]
     },
     "TilgungsArt": {

--- a/api.json
+++ b/api.json
@@ -2902,8 +2902,8 @@
               "type": "integer",
               "format": "int32"
             },
-            "auszahlungsDatumArt": {
-              "$ref": "#/definitions/AuszahlungsDatumArt"
+            "auszahlungsDatumHerkunft": {
+              "$ref": "#/definitions/AuszahlungsDatumHerkunft"
             }
           }
         }
@@ -3239,7 +3239,7 @@
         "ANGEPASST"
       ]
     },
-    "AuszahlungsDatumArt": {
+    "AuszahlungsDatumHerkunft": {
       "type": "string",
       "enum": [
         "IM_WUNSCH_ANGEGEBEN",

--- a/beispiele/anfrage.json
+++ b/beispiele/anfrage.json
@@ -816,6 +816,7 @@
           "tilgungsart": "LAUFEND",
           "volltilgung": false,
           "zinsbindungInMonaten": 240,
+          "auszahlungsDatumArt": "DEFAULT",
           "istEigenvertrieb": true
         }
       ],

--- a/beispiele/anfrage.json
+++ b/beispiele/anfrage.json
@@ -816,7 +816,7 @@
           "tilgungsart": "LAUFEND",
           "volltilgung": false,
           "zinsbindungInMonaten": 240,
-          "auszahlungsDatumArt": "DEFAULT",
+          "auszahlungsDatumHerkunft": "DEFAULT",
           "istEigenvertrieb": true
         }
       ],

--- a/beispiele/antwort.json
+++ b/beispiele/antwort.json
@@ -104,7 +104,8 @@
           "tilgungsart": "LAUFEND",
           "optionaleSondertilgung": "5",
           "volltilgung": false,
-          "zinsbindungInMonaten": 240
+          "zinsbindungInMonaten": 240,
+          "auszahlungsDatumArt": "DEFAULT"
         }
       ],
       "finanzierungsart": "NEUFINANZIERUNG",
@@ -883,6 +884,7 @@
           "optionaleSondertilgung": "5",
           "volltilgung": false,
           "zinsbindungInMonaten": 240,
+          "auszahlungsDatumArt": "DEFAULT",
           "aktionsLabels": [ "Sonderaktion" ]
         },
         "tilgungsPlan": {

--- a/beispiele/antwort.json
+++ b/beispiele/antwort.json
@@ -105,7 +105,7 @@
           "optionaleSondertilgung": "5",
           "volltilgung": false,
           "zinsbindungInMonaten": 240,
-          "auszahlungsDatumArt": "DEFAULT"
+          "auszahlungsDatumHerkunft": "DEFAULT"
         }
       ],
       "finanzierungsart": "NEUFINANZIERUNG",
@@ -884,7 +884,7 @@
           "optionaleSondertilgung": "5",
           "volltilgung": false,
           "zinsbindungInMonaten": 240,
-          "auszahlungsDatumArt": "DEFAULT",
+          "auszahlungsDatumHerkunft": "DEFAULT",
           "aktionsLabels": [ "Sonderaktion" ]
         },
         "tilgungsPlan": {


### PR DESCRIPTION
**Motivation**
--
In der PEP-ME wird es zukünftig eine Vorbehaltsmeldung geben, die darauf prüft, ob zu allen Annuitätendarlehenswünschen ein Auszahlungsdatum angegeben wurde. Diese Vorbehaltsmeldung soll perspektivisch auch bei FINMAS und GENOPACE genutzt werden.

https://europace.atlassian.net/browse/BEV-157
https://github.com/hypoport/pep-market-engine/pull/503

**Technische Anpassungen**
--
Ich habe die api.json erweitert um das Enum "auszahlungsDatumArt". Dieses beinhaltet die Information, aus welcher Quelle das Auszahlungsdatum stammt (IM_WUNSCH_ANGEGEBEN,  DEFAULT, KEINE_ANGABE).