### PR TITLE
BEV: "AnnuitaetOption" erweitert um "AuszahlungsDatumHerkunft"

### DIFF
--- a/api.json
+++ b/api.json
@@ -223,6 +223,13 @@
               "$ref": "#/definitions/BausparOption"
             }
           }
+        },
+        {
+          "properties": {
+            "auszahlungsDatumHerkunft": {
+              "$ref": "#/definitions/AuszahlungsDatumHerkunft"
+            }
+          }
         }
       ]
     },

--- a/beispiele/anfrage.json
+++ b/beispiele/anfrage.json
@@ -368,6 +368,7 @@
               },
               "bereitstellungszinsenFreieZeitInMonaten": 2,
               "auszahlungsDatum": "2018-01-31",
+              "auszahlungsDatumHerkunft": "DEFAULT",
               "zahlungsWeise": "MONATLICH",
               "darlehensBetragsVorgabe": {
                 "darlehensBetragsVorgabeTyp": "FESTER_BETRAG",


### PR DESCRIPTION
**Technische Anpassungen**
--

In Ergänzung zu https://github.com/hypoport/europace-productengine-api/pull/24 habe ich auch die "AnnuitaetOption" um das Enum "AuszahlungsDatumHerkunft" erweitert (analog der Market Engine).

https://europace.atlassian.net/browse/BEV-157
https://github.com/hypoport/pep-market-engine/pull/503

**Hinweis**
--
Dieses Enum gibt es nur in der "AnnuitaetOption", nicht in der "ForwardOption".