### PR TITLE
BEV: Property "auszahlungsDatumHerkunft" verschoben

### DIFF
--- a/api.json
+++ b/api.json
@@ -221,11 +221,7 @@
           "properties": {
             "ausgesetztDurchBausparvertrag": {
               "$ref": "#/definitions/BausparOption"
-            }
-          }
-        },
-        {
-          "properties": {
+            },
             "auszahlungsDatumHerkunft": {
               "$ref": "#/definitions/AuszahlungsDatumHerkunft"
             }


### PR DESCRIPTION
Neue Property "auszahlungsDatumHerkunft" an die korrekte Stelle der AnnuitaetOption verschoben, da sonst "ausgesetztDurchBausparvertrag" überschrieben wird

https://europace.atlassian.net/browse/BEV-157