### PR TITLE
[BEV-651] neue Property "bestehendeKontoverbindungen"

### DIFF
--- a/api.json
+++ b/api.json
@@ -1701,6 +1701,9 @@
         "ratenEinzugsKonto": {
           "$ref": "#/definitions/Kontoverbindung"
         },
+        "bestehendeKontoverbindungen": {
+          "$ref": "#/definitions/BestehendeKontoverbindungen"
+        },
         "verbindlichkeiten": {
           "type": "array",
           "items": {
@@ -2709,6 +2712,20 @@
         },
         "kreditInstitut": {
           "type": "string"
+        }
+      }
+    },
+    "BestehendeKontoverbindungen": {
+      "type": "object",
+      "properties": {
+        "kontowechselWirdBeabsichtigt": {
+          "type": "boolean"
+        },
+        "bestehendeKontoverbindungBei": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         }
       }
     },

--- a/beispiele/anfrage.json
+++ b/beispiele/anfrage.json
@@ -342,6 +342,12 @@
         ],
         "kreditInstitut": "Testumgebung"
       },
+      "bestehendeKontoverbindungen": {
+        "kontowechselWirdBeabsichtigt": true,
+        "bestehendeKontoverbindungBei": [
+          "SPK_MUSTER"
+        ]
+      },
       "verbindlichkeiten": [],
       "zusaetzlicheKapitalBeschaffung": "0,00",
       "zusatzprodukte": [],


### PR DESCRIPTION
Der neue Typ wird benötigt, damit in FINMAS auf einen Kontowechsel geprüft und evtl. ein Margenabschlag vorgenommen werden kann.

Zugrundeliegendes Ticket:
https://europace.atlassian.net/browse/BEV-651

PR der pep-market-engine:
https://github.com/hypoport/pep-market-engine/pull/1431