### PR TITLE
mehr Ratenschutz-Informationen ergänzt, zwecks Anrechnung im BLA

### DIFF
--- a/api.json
+++ b/api.json
@@ -1467,6 +1467,26 @@
         },
         "versicherungsBeitrag": {
           "$ref": "#/definitions/Money"
+        },
+        "zahlweise": {
+          "type": "string",
+          "enum": [
+            "JAEHRLICH",
+            "HALBJAEHRLICH",
+            "VIERTELJAERLICH",
+            "MONATLICH",
+            "EINMALZAHLUNG"
+          ]
+        },
+        "finanzierungsWeise": {
+          "type": "string",
+          "enum": [
+            "DURCH_HAUPTDARLEHEN",
+            "INDIVIDUELL"
+          ]
+        },
+        "zugeordnetesDarlehenId": {
+          "$ref": "#/definitions/Identifier"
         }
       }
     },

--- a/beispiele/anfrage.json
+++ b/beispiele/anfrage.json
@@ -81,7 +81,12 @@
           "produzent": {
             "value": "CREDIT_LIFE"
           },
-          "versicherungsBeitrag": "5.370,00"
+          "versicherungsBeitrag": "5.370,00",
+          "zahlweise": "EINMALZAHLUNG",
+          "finanzierungsWeise": "DURCH_HAUPTDARLEHEN",
+          "zugeordnetesDarlehenId": {
+            "value": "5adaet5a4e6da566431987"
+          }
         }
       ]
     },


### PR DESCRIPTION
Story [BEV-864] | [ITDEV-96]

[BEV-864]: https://europace.atlassian.net/browse/BEV-864
[ITDEV-96]: https://finmas.atlassian.net/browse/ITDEV-96

- Finmas möchte den Anteil des Darlehensbetrags, der durch eine Ratenschutzversicherung-Einmalprämie im Hauptdarlehen zustande kommt, separat im Beleihungsauslauf prozentual anrechnen können.
- In der PE ist diese Information aber nicht ersichtlich, insbesondere wenn mehrere Ratenschutzversicherungen / Darlehen zum Angebot gehören. ("Ist in diesem Darlehen der Betrag einer RSV enthalten?" / "Wurde diese RSV in einem Darlehen mitfinanziert?")
- Daher wollen wir übertragen,
  - a) _zu welchem_ Darlehen eine RSV potentiell gehört (`zugeordnetesDarlehenId`)
  - b) welche Zahlweise und Finanzierungsweise (`zahlweise` , `finanzierungsWeise `) zugrunde liegen, um entscheiden zu können, _ob_ eine RSV in einem Darlehen mitfinanziert wurde