### PR TITLE
Erweiterung Vorlasten

### DIFF
--- a/api.json
+++ b/api.json
@@ -2164,6 +2164,12 @@
         "glaeubiger": {
           "type": "string"
         },
+        "grundschuld": {
+          "$ref": "#/definitions/Money"
+        },
+        "restschuld": {
+          "$ref": "#/definitions/Money"
+        },
         "status": {
           "type": "string",
           "enum": [

--- a/api.json
+++ b/api.json
@@ -2180,7 +2180,9 @@
           ]
         },
         "wert": {
-          "$ref": "#/definitions/Money"
+          "$ref": "#/definitions/Money",
+          "deprecated": true,
+          "description": "Dieses Feld ist mit dem Feld grundschuld abgelöst."
         }
       }
     },

--- a/beispiele/anfrage.json
+++ b/beispiele/anfrage.json
@@ -308,7 +308,15 @@
           "objektArt": "EINFAMILIENHAUS",
           "stellplaetze": {},
           "verwendungsZweck": "KAUF",
-          "vorlasten": [],
+          "vorlasten": [
+            {
+              "abteilung": "ABTEILUNG2",
+              "glaeubiger": "ABC",
+              "grundschuld": "200.000,00",
+              "restschuld": "50.000,00",
+              "status": "BLEIBT_BESTEHEN"
+            }
+          ],
           "wohnlage": "SEHR_GUT",
           "vdpObjektbewertung": {
             "meldungen": [


### PR DESCRIPTION
[ITDEV-156]

Analog Speed (**PPK-1681**) sollen in der Finmas PE die Vorlasten mit Restschuld bewertet werden können.

Dazu muss die Restschuld übertragen werden.

Im Rahmen von **PPK-1344** wurde außerdem das Feld `wert` in `grundschuld` umbenannt. Um späterer Verwirrung vorzubeugen, empfiehlt es sich wahrscheinlich, das auch in PAPI umzubenennen. Wie wollen wir mit sowas umgehen? (deprecated Felder usw.)

[ITDEV-156]: https://finmas.atlassian.net/browse/ITDEV-156