### PR TITLE
Erweiterung FinanzierungsSpezifikation um Alternative

### DIFF
--- a/api.json
+++ b/api.json
@@ -2944,6 +2944,9 @@
         "sollProvisionOptimiertWerden": {
           "type": "boolean"
         },
+        "alternative": {
+          "type": "boolean"
+        },
         "vertriebsGruppe": {
           "type": "string"
         }

--- a/beispiele/anfrage.json
+++ b/beispiele/anfrage.json
@@ -846,6 +846,7 @@
         "value": "0123456789"
       },
       "sollProvisionOptimiertWerden": false,
+      "alternative": false,
       "vertriebsGruppe": ""
     }
   }


### PR DESCRIPTION
[ITDEV-159]

Eine Anforderung für neue Machbarkeitsregeln lautet:
> Bitte schaut darauf, dass die Alternativen [...] nicht beeinträchtigt werden.

Bei der Angebotsberechnung in den PEs wissen wir bisher nicht wirklich, ob der gerade zu berechnende Baustein Teil einer Alternative ist. Analog der `FinanzierungsOption` (die nur im `OptionsShowStopperInput` übertragen wird), soll diese Info in die `FinanzierungsSpezifikation` gepflanzt werden, um Regeln auf Alternativen einschränken bzw. von ihnen ausschließen zu können.

[ITDEV-159]: https://finmas.atlassian.net/browse/ITDEV-159