### PR TITLE
`ZielBeleihungsAuslaufVorgabeFuerOptionsGruppe` erweitert

### DIFF
--- a/api.json
+++ b/api.json
@@ -3334,6 +3334,9 @@
             },
             "hoechstSummeDarlehen": {
               "$ref": "#/definitions/Money"
+            },
+            "rundeAufVolleTausender": {
+              "type": "boolean"
             }
           }
         }


### PR DESCRIPTION
Neues Flag `rundeAufVolleTausender` eingeführt, damit in `SpeedDarlehenBlaVorgabenVerarbeitung` wieder auf volle Tausender (geändert in https://github.com/hypoport/pep-market-engine/commit/ead7469f04ae7968f3d8260c1df627eda70b1c61) gerundet werden kann. Damit wird ein Überschreiten des Zielbeleihungsauslaufs durch ein mögliches Aufrunden in `SpeedMachbarkeitFinanzierungsLoesungRegeln` ('pe.speed.machbarkeit.finanzierungsloesung.darlehen.betrag.34') verhindert.

https://github.com/genopace/entwicklung/issues/559