### PR TITLE
Erweiterung FremdBausparInformation um Tarif

### DIFF
--- a/api.json
+++ b/api.json
@@ -1541,6 +1541,9 @@
         "produzentLangname": {
           "type": "string"
         },
+        "tarif": {
+          "type": "string"
+        },
         "sparBeitragMonatlich": {
           "$ref": "#/definitions/Money"
         },

--- a/beispiele/anfrage.json
+++ b/beispiele/anfrage.json
@@ -4,7 +4,33 @@
   "nachrangDarlehenIgnorieren": false,
   "offerworkflowInput": {
     "fremdProduktInformationen": {
-      "fremdBausparInformationen": [],
+      "fremdBausparInformationen": [
+        {
+          "abschlussGebuehr": "500,00",
+          "auszahlungsBetragBeiZuteilung": "60.000,00",
+          "bausparSumme": "100.000,00",
+          "einmalZahlung": "10.000,00",
+          "identifier": "abc123",
+          "produzent": "LBS_WEST",
+          "produzentLangname": "LBS West",
+          "tarif": "tarif_xyz",
+          "sparBeitragMonatlich": "123,45",
+          "vertragsBeginn": "2022-08-01",
+          "verwaltungsGebuehrJaehrlich": "10,00",
+          "verwendung": "TILGUNGSERSATZ",
+          "zahlungsStrom": [
+            {
+              "betrag": "543.21",
+              "datum": "2022-08-31"
+            },
+            {
+              "betrag": "543.21",
+              "datum": "2022-09-30"
+            }
+          ],
+          "zuteilungsDatum": "2035-01-01"
+        }
+      ],
       "fremdDarlehenInformationen": [
         {
           "anfaenglicherTilgungssatz": "3,508",


### PR DESCRIPTION
[ITDEV-283], rel: https://github.com/hypoport/efi-bausparservice-api/pull/9 , https://github.com/hypoport/wbsk-service/pull/188

Copy & Paste aus anderen PRs:

Bei ausgesetzten LBS-Darlehen soll der Bauspar-Tarif die Konditionen des zugehörigen Darlehens beeinflussen.
Dafür muss der an die Finmas PE übertragen werden:

wBSK: `Bausparangebot` -> `BausparAngebot`
PEP ME: `BausparAngebot` -> `OfferEngineAustauschBausparvertrag` -> `SpeedFremdBausparInformation`
PEP ME -> Finmas PE: via Erweiterung PAPI FremdBausparInformation

[ITDEV-283]: https://finmas.atlassian.net/browse/ITDEV-283