### PR TITLE
[BD-197] BAUSPARDARLEHEN beim darlehensTyp ergänzt

### DIFF
--- a/api.json
+++ b/api.json
@@ -541,6 +541,7 @@
           "type": "string",
           "enum": [
             "ANNUITAETENDARLEHEN",
+            "BAUSPARDARLEHEN",
             "BAUSPARSOFORTDARLEHEN",
             "CAPDARLEHEN",
             "FORWARDDARLEHEN",

--- a/beispiele/anfrage.json
+++ b/beispiele/anfrage.json
@@ -97,6 +97,33 @@
           "tilgungsart": "LAUFEND",
           "zahlungsWeise": "MONATLICH",
           "zinsBindungInMonaten": 120
+        },
+        {
+          "anfaenglicherTilgungssatz": "1,238",
+          "auszahlungsDatum": "2018-01-31",
+          "auszahlungsKurs": "100",
+          "bausteinOrdnung": "GEMEINSAM",
+          "bereitstellungsZins": "0",
+          "darlehensBetrag": "89.000,00",
+          "darlehensTyp": "BAUSPARDARLEHEN",
+          "effektivzins": "1,41",
+          "einstandsDatum": "2018-01-11T12:11:14.265Z",
+          "endeZinsbindung": "2028-01-31",
+          "identifier": {
+            "value": "6266253156150222"
+          },
+          "kalkulatorischeLaufzeitInMonaten": 120,
+          "monatlicheRate": "167,70",
+          "produzentenId": {
+            "value": "LBS_BAYERN"
+          },
+          "produzentLangname": "LBS Bayern",
+          "restschuldNachZinsbindung": "0",
+          "sollzins": "1,4",
+          "tilgungsErsatzProdukte": [],
+          "tilgungsart": "LAUFEND",
+          "zahlungsWeise": "MONATLICH",
+          "zinsBindungInMonaten": 120
         }
       ],
       "fremdRatenschutzInformationen": [


### PR DESCRIPTION
Das `BAUSPARDARLEHEN` wird über den wbsk-Bausparservice berechnet und innerhalb der MarketEngine als OfferEngineAustauschDarlehen weitergereicht. Damit diese Information auch über die PAPI mitgeschickt werden kann, muss der `darlehensTyp` (Enum) erweitert werden.

Story: [BD-197](https://europace.atlassian.net/browse/BD-197)