### PR TITLE
Neuer Darlehen-Options-Typ `SingulaereDarlehensOptionMitAnderemKreditentscheider`

### DIFF
--- a/api.json
+++ b/api.json
@@ -133,7 +133,8 @@
             "SINGULAERES_FOERDER",
             "SINGULAERES_KFW",
             "VARIABLES_DARLEHEN",
-            "ZWIFI"
+            "ZWIFI",
+            "SINGULAERES_DARLEHEN_MIT_ANDEREM_KREDITENTSCHEIDER"
           ]
         },
         "identifier": {
@@ -150,6 +151,9 @@
         },
         "produktEigenschaften": {
           "$ref": "#/definitions/ProduktEigenschaften"
+        },
+        "singulaer": {
+          "type": "boolean"
         }
       }
     },
@@ -368,6 +372,20 @@
           "properties": {
             "bezugsOption": {
               "$ref": "#/definitions/KfwOption"
+            }
+          }
+        }
+      ]
+    },
+    "SingulaereDarlehensOptionMitAnderemKreditentscheider": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/DarlehensOption"
+        },
+        {
+          "properties": {
+            "bezugsOption": {
+              "$ref": "#/definitions/DarlehensOption"
             }
           }
         }


### PR DESCRIPTION
Mit Diesem lassen sich beliebige Darlehenoptionen als singulär mit anderem Kreditentscheider behandeln

genopace/entwicklung#1182
genopace/entwicklung#1175