### PR TITLE
Erweiterung DarlehenEinerImmobilie um Darlehensbetrag

### DIFF
--- a/api.json
+++ b/api.json
@@ -2714,6 +2714,9 @@
         "darlehenEinerFinanzierungsImmobilie": {
           "type": "boolean"
         },
+        "darlehensbetrag": {
+          "$ref": "#/definitions/Money"
+        },
         "darlehensGeber": {
           "type": "array",
           "items": {

--- a/beispiele/anfrage.json
+++ b/beispiele/anfrage.json
@@ -633,7 +633,29 @@
         "value": "SPK_MUSTER"
       },
       "produzentenAnfrage": {
-        "abzuloesendeDarlehen": [],
+        "abzuloesendeDarlehen": [
+          {
+            "abzuloesendeRestschuld": "120.000,00",
+            "aktuelleRestschuld": "150.000,00",
+            "darlehenEinerFinanzierungsImmobilie": true,
+            "darlehensbetrag": "200.000,00",
+            "darlehensGeber": {
+              "value": "SPK_MUSTER"
+            },
+            "darlehensGeberBezeichnung": "Muster Sparkasse",
+            "darlehensKontonummer": "4122000535",
+            "darlehensTyp": "IMMOBILIENDARLEHEN",
+            "endeLaufzeit": "2040-01-10",
+            "grundschuld": "200.000,00",
+            "identifier": {
+              "value": "763503285908"
+            },
+            "monatlicheRate": "300,00",
+            "sollZins": "2,3",
+            "sondertilgungZumZinsbindungsende": "0,00",
+            "zinsbindungsEnde": "2025-06-01"
+          }
+        ],
         "anzahlAuszahlungen": 1,
         "auszahlungsKonto": {
           "bic": "PBNKDEFFXXX",


### PR DESCRIPTION
[Axilaris Ticket#202209091000112](https://support.axs4u.de)

Zur Berechnung der kalkulatorischen Rate nicht abzulösender Darlehen (`SpeedNichtAbzuloesendeDarlehenKalkulatorischeRatenErmittler` bei Speed & Finmas) sind im Customizing (`SpeedBasisKalkulatorischeRate`) die Varianten `RESTSCHULD_ZUM_ABLOESEDATUM` & `DARLEHENSSUMME` vorgesehen.
Aktuell wird bei ersterem vom bestehenden Darlehen das Feld `abzuloesendeRestschuld` herangezogen, bei letzterem das Feld `aktuelleRestschuld`.

Laut Finmas wäre bei letzterem jedoch der Darlehensbetrag korrekt, der wird aber noch nicht übertragen.