### PR TITLE
add oneclick-property to api

### DIFF
--- a/api.json
+++ b/api.json
@@ -668,6 +668,9 @@
         "schnelleKreditbetriebsBearbeitung": {
           "type": "boolean"
         },
+        "oneClick": {
+          "type": "boolean"
+        },
         "kreditbetriebsVorgabe": {
           "$ref": "#/definitions/KreditbetriebsVorgabe"
         },

--- a/beispiele/antwort.json
+++ b/beispiele/antwort.json
@@ -4199,6 +4199,7 @@
     ],
     "elektronischeUnterlagenEinreichung": true,
     "schnelleKreditbetriebsBearbeitung": true,
+    "oneClick": true,
     "kreditbetriebsVorgabe": {
       "kreditEntscheider": {
         "value": "SPK_MUSTERBANK"


### PR DESCRIPTION
Um das property "oneClick" auch für Finmas produkte zu erhalten, wird es hier hinzugefügt. Es dient der Identifikation von Angeboten, die Oneclick sind.