### PR TITLE
[BD-1116] Fix spec for compatibility to swagger-codegen-maven-plugin 2.4.32

### DIFF
--- a/api.json
+++ b/api.json
@@ -233,6 +233,9 @@
       "allOf": [
         {
           "$ref": "#/definitions/TilgungsDarlehensOption"
+        },
+        {
+          "type": "object"
         }
       ]
     },
@@ -314,6 +317,9 @@
       "allOf": [
         {
           "$ref": "#/definitions/GemeinsameAttributeDarlehensOption"
+        },
+        {
+          "type": "object"
         }
       ]
     },
@@ -505,10 +511,10 @@
       }
     },
     "Money": {
-      "type": "number"
+      "type": "object"
     },
     "Identifier": {
-      "type": "string"
+      "type": "object"
     },
     "FremdDarlehenInformation": {
       "type": "object",
@@ -1618,7 +1624,7 @@
       }
     },
     "Percent": {
-      "type": "number"
+      "type": "object"
     },
     "PercentRange": {
       "type": "object",
@@ -3342,6 +3348,9 @@
       "allOf": [
         {
           "$ref": "#/definitions/DarlehensBetragsVorgabe"
+        },
+        {
+          "type": "object"
         }
       ]
     },
@@ -3479,6 +3488,9 @@
       "allOf": [
         {
           "$ref": "#/definitions/TilgungsOption"
+        },
+        {
+          "type": "object"
         }
       ]
     },
@@ -3514,6 +3526,9 @@
       "allOf": [
         {
           "$ref": "#/definitions/TilgungsOption"
+        },
+        {
+          "type": "object"
         }
       ]
     },
@@ -3548,6 +3563,9 @@
       "allOf": [
         {
           "$ref": "#/definitions/SondertilgungsOption"
+        },
+        {
+          "type": "object"
         }
       ]
     },


### PR DESCRIPTION
[BD-1116]

The current spec is not compatible with current swagger-codegen-maven-plugin version 2.4.32. It generates non-compilable code. The non-semantic changes in this PR fix the issue.

## Technical changes
- new plugin versions >=2.3  will replace `Percent` and `Money` with `BigDecimal` if declared as type `number`; the import mappings in plugin configuration don't have any effect
  ```
    <importMappings>
        Money=de.hypoport.ef2.core.money.Money,
        Percent=de.hypoport.ef2.core.math.Percent,
        ...
    </importMappings>
  ```
- same with `Identifier`, which will be replaced with `String`
- non-compilable classes generated in new plugin version >=2.4.15 if `type`-property absent in inheritated types. 
  For example
  ```
  public class PapiEndfaelligOption extends PapiTilgungsOption {
  
    @Override
    public boolean equals(java.lang.Object o) {
      if (this == o) { return true; }
      if (o == null || getClass() != o.getClass()) { return false; }
      return super.equals(o);
    }
  ...
  ```
  becomes
  ```
  public class PapiEndfaelligOption extends PapiTilgungsOption {
  
    @Override
    public boolean equals(java.lang.Object o) {
      if (this == o) { return true; }
      if (o == null || getClass() != o.getClass()) { return false; }
      PapiEndfaelligOption endfaelligOption = (PapiEndfaelligOption) o;
      return  &&
        super.equals(o);
    }
  ...
  ```

  (version 2.4.15 introduced thread-safety, that actually solved problems in code generation in parallel; with our configuration it somehow added problems :cry: )

## Tests
Tested in Market-Engine with `swagger-codegen-maven-plugin:2.4.32`.


[BD-1116]: https://europace.atlassian.net/browse/BD-1116?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ