### PR TITLE
Remove `Darlehensnehmer.produzentEigeneBestehendeImmobilienKredite`

### DIFF
--- a/api.json
+++ b/api.json
@@ -2426,9 +2426,6 @@
         },
         "ausweis": {
           "$ref": "#/definitions/Ausweis"
-        },
-        "produzentEigeneBestehendeImmobilienKredite": {
-          "$ref": "#/definitions/Money"
         }
       }
     },

--- a/beispiele/anfrage.json
+++ b/beispiele/anfrage.json
@@ -219,8 +219,7 @@
             "ausstellendeBehoerde": "BA Irgendwo",
             "art": "PERSONALAUSWEIS",
             "ausstellungsDatum": "1970-01-01"
-          },
-          "produzentEigeneBestehendeImmobilienKredite": "0,00"
+          }
         }
       ],
       "effektivZinsKosten": {},
@@ -729,8 +728,7 @@
               "ausstellendeBehoerde": "BA Irgendwo",
               "art": "PERSONALAUSWEIS",
               "ausstellungsDatum": "1970-01-01"
-            },
-            "produzentEigeneBestehendeImmobilienKredite": "0,00"
+            }
           }
         ],
         "effektivZinsKosten": {},


### PR DESCRIPTION
The field is unused in the FINMAS PE. In the AngebotsService app this field is mapped by code otherwise only used by Genopace. Genopace wants to change the behavior of that code. Removing this field make it safe to do so.

See ME: BaufiSmartVerbindlichkeitenBestehendeImmobilienTransformer 

Depends on https://github.com/hypoport/pep-market-engine/pull/5902 for safe deployment. There I remove the mapping.

closes https://github.com/genopace/entwicklung/issues/2033 nicht mal ansatzweise